### PR TITLE
Updated so e2e tests can be run in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM quay.io/ukhomeofficedigital/nodejs-base:v4.4.2
+
+RUN yum clean all && \
+    yum update -y && \
+    yum install -y git make gcc-c++ psmisc && \
+    yum clean all && \
+    rpm --rebuilddb && \
+    mkdir -p /app/mock
+
+WORKDIR /tests
+COPY ./package.json /tests/
+RUN npm install --quiet
+
+COPY . /tests
+
+ENTRYPOINT ["/tests/node_modules/dredd/bin/dredd"]

--- a/README.md
+++ b/README.md
@@ -31,8 +31,18 @@ dredd --server false --server-wait 0 --endpoint http://localhost:8080
 ### Running tests against server with oauth2 authentication enabled (assuming server running already)
 Environment variables need to be set for oauth properties, e.g.
 ```bash
-KEYCLOAK_U=dredd-tests KEYCLOAK_P="password" REALM=lev-api-dev CLIENT_ID=dredd-tests CLIENT_SECRET=gfkdjhgkdfhg \
+KEYCLOAK_U=dredd-tests KEYCLOAK_P="xxxxx" REALM=lev-api-dev CLIENT_ID=dredd-tests CLIENT_SECRET=xxxxxx \
 dredd --server false --server-wait 0 --endpoint http://localhost:8080 --hookfiles=./hooks/oauth2.js
+```
+
+### Running tests with docker
+```bash
+docker build -t lev-api-e2e-tests .
+docker run --rm --net=host -e KEYCLOAK_U=dredd-tests -e KEYCLOAK_P="xxxxxx" \
+-e REALM=lev-api-dev -e CLIENT_ID=dredd-tests -e \
+CLIENT_SECRET=xxxxxx lev-api-e2e-tests \
+--server false --server-wait 0 --endpoint https://lev-api-dev.notprod.homeoffice.gov.uk \
+--hookfiles=./hooks/oauth2.js
 ```
 
 ### Viewing full test report


### PR DESCRIPTION
Don't know why but tests only work with --net=host
